### PR TITLE
Fix to check for null bitmaps caused by decoding errors on some phones.

### DIFF
--- a/src/android/NativeCameraLauncher.java
+++ b/src/android/NativeCameraLauncher.java
@@ -147,6 +147,12 @@ public class NativeCameraLauncher extends CordovaPlugin {
 							.decodeStream(resolver.openInputStream(uri));
 				}
 
+				// If bitmap cannot be decoded, this may return null
+				if (bitmap == null) {
+					this.failPicture("Error decoding image.");
+					return;
+				}
+
 				bitmap = scaleBitmap(bitmap);
 
 				// Create entry in media store for image


### PR DESCRIPTION
Some phones (Tecno P5) produce jpegs that can't be decoded for some reason. We should catch the decoding to fail gracefully
