### PR TITLE
Major simplification of NativeCameraLauncher

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
            id="com.wezka.nativecamera"
-      version="0.1.1">
+      version="0.1.2">
     <name>Wezka Native Camera</name>
 
     <js-module src="www/CameraConstants.js" name="Camera">

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -425,7 +425,7 @@ public class CameraActivity extends Activity implements SensorEventListener {
                     }
                     if (parameters.getSupportedWhiteBalance() != null) {
                         if (parameters.getSupportedWhiteBalance().contains(Camera.Parameters.WHITE_BALANCE_AUTO)) {
-                            parameters.setSceneMode(Camera.Parameters.WHITE_BALANCE_AUTO);
+                            parameters.setSupportedWhiteBalance(Camera.Parameters.WHITE_BALANCE_AUTO);
                         }
                     }
                     cameraConfigured=true;

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -425,7 +425,7 @@ public class CameraActivity extends Activity implements SensorEventListener {
                     }
                     if (parameters.getSupportedWhiteBalance() != null) {
                         if (parameters.getSupportedWhiteBalance().contains(Camera.Parameters.WHITE_BALANCE_AUTO)) {
-                            parameters.setSupportedWhiteBalance(Camera.Parameters.WHITE_BALANCE_AUTO);
+                            parameters.setWhiteBalance(Camera.Parameters.WHITE_BALANCE_AUTO);
                         }
                     }
                     cameraConfigured=true;


### PR DESCRIPTION
The plugin was failing under Android 4.0.4, reporting that a file was not found.

The problem was in the attempt to insert the photo into the media library somewhere. Since we just want a picture that the app can then manipulate, rather than keeping it in perpetuity on the phone in the media library, we removed the code that attempted to add it and greatly simplified the process as a result. It now works fine.
